### PR TITLE
Fix linker version check command format

### DIFF
--- a/mozjs-sys/mozjs/build/moz.configure/toolchain.configure
+++ b/mozjs-sys/mozjs/build/moz.configure/toolchain.configure
@@ -1753,7 +1753,7 @@ def select_linker_tmpl(host_or_target):
             die("Unsupported linker " + linker)
 
         # Check the kind of linker
-        version_check = ["-Wl,--version"]
+        version_check = ["-Wl", "--version"]
         cmd_base = c_compiler.wrapper + [c_compiler.compiler] + c_compiler.flags
 
         def try_linker(linker):


### PR DESCRIPTION
The linker version check command was incorrectly formatted in the toolchain configuration. This update corrects the format by splitting the flags into separate elements of the version_check list. This change will ensure the command parses correctly.